### PR TITLE
Use hostname as avahi service name

### DIFF
--- a/_release/cacophonator-management-avahi.service
+++ b/_release/cacophonator-management-avahi.service
@@ -1,6 +1,6 @@
 <service-group>
-  <name>cacophony</name>
-  <service protocol="ipv4">
+  <name replace-wildcards="yes">%h</name>
+  <service>
     <type>_cacophonator-management._tcp</type>
     <port>80</port>
   </service>


### PR DESCRIPTION
The service name should be unique so that multiple instances of the service can be distinguished. The hostname is a good choice.

Also, don't restrict to advertising just for IPv4. There's no reason we can't use IPv6 as well.