### PR TITLE
Advertise as IPv4 only

### DIFF
--- a/_release/cacophonator-management-avahi.service
+++ b/_release/cacophonator-management-avahi.service
@@ -1,6 +1,6 @@
 <service-group>
   <name replace-wildcards="yes">%h</name>
-  <service>
+  <service protocol="ipv4">
     <type>_cacophonator-management._tcp</type>
     <port>80</port>
   </service>


### PR DESCRIPTION
Chrome Mobile doesn't seem to support IPv6