### PR TITLE
Fixed reversing error in log entries.

### DIFF
--- a/audiobait.go
+++ b/audiobait.go
@@ -38,7 +38,7 @@ import (
 func getAudiobaitLogEntries() string {
 
 	logEntries := make([]string, 0)
-	out, err := exec.Command("/bin/journalctl", "--no-pager", "-u", "audiobait", "-n", "100", "--reverse").Output()
+	out, err := exec.Command("/bin/journalctl", "-u", "audiobait", "--no-pager", "-n", "100").Output()
 	if err != nil {
 		log.Println("Could not get audio bait logging info:", err)
 		return "Could not get audio bait logging info."
@@ -60,6 +60,10 @@ func getAudiobaitLogEntries() string {
 			logEntries = append(logEntries, line)
 		}
 	}
+
+	// Show newest log entries first.  Note that the --reverse option for the journalctl command above does
+	// not seem to work with the -u option.  So doing it here.
+	reverse(logEntries)
 
 	// Now combine back into 1 string.
 	outputText := ""

--- a/helpers.go
+++ b/helpers.go
@@ -128,3 +128,10 @@ func errorMessage(err error) string {
 	return err.Error()
 }
 
+// Reverse a slice of strings in place.
+func reverse(ss []string) {
+	last := len(ss) - 1
+	for i := 0; i < len(ss)/2; i++ {
+		ss[i], ss[last-i] = ss[last-i], ss[i]
+	}
+}


### PR DESCRIPTION
Menno, this fixes the error in log entries.  The -u and the -r (same as --reverse) options don't seem to play well together.

So I'm reversing the entries in Golang again.

Also, when the audiobait service is restarted, the schedule is downloaded again as you know.  So if someone clicks 'reset', then immediately clicks 'recent logs' they will see the log entries saying the service has been restarted, but they won't see all the log entries related to the schedule being renewed - cause it takes like 20 secs or so for it to do so.

But if you show the logs again after then, it's all there.