### PR TITLE
Speed up changing device name

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Run Go Tests
         run: go test ./...
 
+      - name: Install Staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+
+      - name: Run Staticcheck
+        run: staticcheck --checks="all,-ST1000,-ST1022,-ST1020,-ST1003" ./...
+
       - name: Check GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/_release/managementd.service
+++ b/_release/managementd.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Cacophonator management interface
 After=network.target
+ConditionPathExists=/etc/salt/minion_id
 
 [Service]
 ExecStart=/usr/bin/managementd

--- a/api/api.go
+++ b/api/api.go
@@ -85,9 +85,9 @@ func NewAPI(router *mux.Router, config *goconfig.Config, appVersion string, l *l
 	}, nil
 }
 
-func (s *ManagementAPI) StopHotspotTimer() {
-	if s.hotspotTimer != nil {
-		s.hotspotTimer.Stop()
+func (api *ManagementAPI) StopHotspotTimer() {
+	if api.hotspotTimer != nil {
+		api.hotspotTimer.Stop()
 	}
 }
 
@@ -105,7 +105,7 @@ func checkIsConnectedToNetworkWithRetries() (string, error) {
 	return ssid, err
 }
 
-func (server *ManagementAPI) ManageHotspot() {
+func (api *ManagementAPI) ManageHotspot() {
 	// Check if we are connected to a network
 	ssid, err := checkIsConnectedToNetworkWithRetries()
 	if err != nil {

--- a/cmd/managementd/main.go
+++ b/cmd/managementd/main.go
@@ -47,7 +47,6 @@ import (
 	netmanagerclient "github.com/TheCacophonyProject/rpi-net-manager/netmanagerclient"
 	"github.com/TheCacophonyProject/thermal-recorder/headers"
 	"github.com/alexflint/go-arg"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -64,7 +63,7 @@ var (
 	headerInfo  *headers.HeaderInfo
 	frameCh     = make(chan *FrameData, 4)
 	connected   atomic.Bool
-	log         *logrus.Logger
+	log         = logging.NewLogger("info")
 )
 
 type Args struct {

--- a/cmd/managementd/main.go
+++ b/cmd/managementd/main.go
@@ -273,15 +273,15 @@ func handleConn(conn net.Conn) error {
 
 	log.Printf("connection from %s %s (%dx%d@%dfps) frame size %d", headerInfo.Brand(), headerInfo.Model(), headerInfo.ResX(), headerInfo.ResY(), headerInfo.FPS(), headerInfo.FrameSize())
 
-	var clearB []byte = make([]byte, 5)
+	clearB := make([]byte, 5)
 	_, err = io.ReadFull(reader, clearB)
 	if err != nil {
 		return err
 	}
 
 	rawFrame := make([]byte, headerInfo.FrameSize())
-	var frame *cptvframe.Frame = cptvframe.NewFrame(headerInfo)
-	var frames int = 0
+	frame := cptvframe.NewFrame(headerInfo)
+	frames := 0
 	var lastFrame *FrameData
 	connected.Store(true)
 	for {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.3
 require (
 	github.com/TheCacophonyProject/audiobait/v3 v3.0.1
 	github.com/TheCacophonyProject/event-reporter v1.3.2-0.20200210010421-ca3fcb76a231
-	github.com/TheCacophonyProject/go-api v1.2.1
+	github.com/TheCacophonyProject/go-api v1.2.2
 	github.com/TheCacophonyProject/go-config v1.22.0
 	github.com/TheCacophonyProject/go-cptv v0.0.0-20211109233846-8c32a5d161f7
 	github.com/TheCacophonyProject/lepton3 v0.0.0-20211005194419-22311c15d6ee
@@ -19,12 +19,11 @@ require (
 )
 
 require (
-	github.com/TheCacophonyProject/go-utils v0.1.1
+	github.com/TheCacophonyProject/go-utils v0.1.3
 	github.com/TheCacophonyProject/rpi-net-manager v0.4.0-deb12
 	github.com/TheCacophonyProject/thermal-recorder v1.22.1-0.20230627011240-89964c0511f7
 	github.com/TheCacophonyProject/trap-controller v0.0.0-20230227002937-262a1adfaa47
 	github.com/alexflint/go-arg v1.4.3
-	github.com/sirupsen/logrus v1.9.3
 	golang.org/x/text v0.16.0
 
 )
@@ -48,6 +47,7 @@ require (
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/sagikazarmark/locafero v0.6.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/TheCacophonyProject/event-reporter/v3 v3.8.0 h1:FYNR+MX5ypyG7UWpogDnD
 github.com/TheCacophonyProject/event-reporter/v3 v3.8.0/go.mod h1:WTppJtTBxduasM1Or5SAh4Mm0YrTDnprOChjnGYgyEI=
 github.com/TheCacophonyProject/go-api v0.0.0-20190923033957-174cea2ac81c/go.mod h1:FfMpa4cFhNXQ9tuKG18HO6yLExezcJhzjUjBOFocrQw=
 github.com/TheCacophonyProject/go-api v1.0.4/go.mod h1:F7UUNgsLhbw7hsiNBMRB9kQz9uXXosVmNToqImz7EA8=
-github.com/TheCacophonyProject/go-api v1.2.1 h1:QS8mzStQHzb3oAqqwjoLqCvXsRM8fx7F9I7hpgKND5c=
-github.com/TheCacophonyProject/go-api v1.2.1/go.mod h1:F7UUNgsLhbw7hsiNBMRB9kQz9uXXosVmNToqImz7EA8=
+github.com/TheCacophonyProject/go-api v1.2.2 h1:lXV2/upgA6lgLWOuTMRJoTjMXxlSveN9v8Dr3mvYqPM=
+github.com/TheCacophonyProject/go-api v1.2.2/go.mod h1:innR3kf5xnua2wbnLvOudI13j2TU1sGY1dxJQJLRZkI=
 github.com/TheCacophonyProject/go-config v0.0.0-20190922224052-7c2a21bc6b88/go.mod h1:gPUJLVu408NRz9/P3BrsxzOzLc+KJLrv+jVdDw3RI0Y=
 github.com/TheCacophonyProject/go-config v0.0.0-20190927054511-c93578ae648a/go.mod h1:QCgT+KCrz1CmLVpeeOMl5L8/X1QvWwpsLzR7afTmEJc=
 github.com/TheCacophonyProject/go-config v1.4.0/go.mod h1:oARW/N3eJbcewCqB+Jc7TBwuODawwYgpo56UO6yBdKU=
@@ -71,8 +71,8 @@ github.com/TheCacophonyProject/go-cptv v0.0.0-20200616224711-fc633122087a/go.mod
 github.com/TheCacophonyProject/go-cptv v0.0.0-20200818214604-bd5d4aa36043/go.mod h1:wG4/P/TsGtk33uBClYPjRlSbcdQrIASXutOUV8LMn2o=
 github.com/TheCacophonyProject/go-cptv v0.0.0-20211109233846-8c32a5d161f7 h1:sf9KTj7u3mFMx5NsLpQtf8FtP3BDZAgtHutanDygQgk=
 github.com/TheCacophonyProject/go-cptv v0.0.0-20211109233846-8c32a5d161f7/go.mod h1:T74NuMjo2YrLoyhAd0+9hj2pgVt8F7DWWzTMlU8aH6k=
-github.com/TheCacophonyProject/go-utils v0.1.1 h1:VOt9EphEqRUYMqKJlJeliIarIMlCVKYGb1fdqM6b4YM=
-github.com/TheCacophonyProject/go-utils v0.1.1/go.mod h1:jZPUZ4GtYVxnlTtqiYKMFWDT//kmxdbwjLW3HCyCmCE=
+github.com/TheCacophonyProject/go-utils v0.1.3 h1:DSuDeJz7ZM00yQRLsoukWH0fnC+8X8+ziYxOl6l3wEY=
+github.com/TheCacophonyProject/go-utils v0.1.3/go.mod h1:jZPUZ4GtYVxnlTtqiYKMFWDT//kmxdbwjLW3HCyCmCE=
 github.com/TheCacophonyProject/lepton3 v0.0.0-20200121020734-2ae28662e1bc/go.mod h1:xzPAWtvVCbJdJC2Gn1cG0Ovs/VP7XGGiQpUU8wU4HME=
 github.com/TheCacophonyProject/lepton3 v0.0.0-20200213011619-1934a9300bd3/go.mod h1:xzPAWtvVCbJdJC2Gn1cG0Ovs/VP7XGGiQpUU8wU4HME=
 github.com/TheCacophonyProject/lepton3 v0.0.0-20200909032119-e2b2b778a8ee/go.mod h1:+FTQKx63hdEbuTe/nxNv9TQ2EWqdlzMZx7UNLGCX9SE=

--- a/signal-strength/signal-strength.go
+++ b/signal-strength/signal-strength.go
@@ -20,7 +20,7 @@ package signalstrength
 
 import (
 	"encoding/xml"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"time"
@@ -57,7 +57,7 @@ func Run() (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
- Added some checks to not run salt commands before the minion ID is set.
- Use latets go-api so it will not wait for the salt grains to be set before returning when renaming the device.
