### PR TITLE
Don't restart the service.

### DIFF
--- a/_release/postinstall.sh
+++ b/_release/postinstall.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 systemctl daemon-reload
 systemctl enable managementd.service
-systemctl restart managementd.service
+
+# Using start instead of restart to avoid restarting the service if it's already running, causing API issues during a salt update.
+systemctl start managementd.service


### PR DESCRIPTION
Service will be restarted by salt during an update, this is so the API doesn't go down part way through an update.
