### PR TITLE
Fix camera not staying on

### DIFF
--- a/cmd/managementd/main.go
+++ b/cmd/managementd/main.go
@@ -86,6 +86,7 @@ func maybeTriggerStayOnFor() {
 		stayOnForMu.Lock()
 		defer stayOnForMu.Unlock()
 		if time.Since(lastStayOn) > time.Minute {
+			log.Debug("triggering stay-on-for 5 minutes")
 			out, err := exec.Command("stay-on-for", "5").CombinedOutput()
 			if err != nil {
 				log.Errorf("error running stay-on-for: %s, error: %v", string(out), err)

--- a/cmd/managementd/main.go
+++ b/cmd/managementd/main.go
@@ -24,7 +24,6 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"github.com/godbus/dbus"
 	"io"
 	"net"
 	"net/http"
@@ -33,6 +32,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/godbus/dbus"
 
 	"github.com/gobuffalo/packr"
 
@@ -75,25 +76,22 @@ func hasActiveClients() bool {
 	return len(sockets) > 0
 }
 
+// maybeTriggerStayOnFor will run the stay-on-for command if needed.
+// The stay-on-for command will stop tc2-hat-attiny from shutting down the RPi.
+// This should be called when there is an API request, as that indicates that a user is using the camera.
+// We throttle this to once every minute to avoid unnecessary calls.
+// Because of the use of mutex we run this is a goroutine to avoid blocking the main thread.
 func maybeTriggerStayOnFor() {
-	stayOnForMu.Lock()
-	shouldRun := lastStayOn.IsZero() || time.Since(lastStayOn) >= 5*time.Minute
-	if shouldRun {
-		lastStayOn = time.Now()
-	}
-	stayOnForMu.Unlock()
-
-	if !shouldRun {
-		return
-	}
-
 	go func() {
-		out, err := exec.Command("stay-on-for", "5").CombinedOutput()
-		if err != nil {
-			log.Printf("error running stay-on-for: %s, error: %v", string(out), err)
-			stayOnForMu.Lock()
-			lastStayOn = time.Time{}
-			stayOnForMu.Unlock()
+		stayOnForMu.Lock()
+		defer stayOnForMu.Unlock()
+		if time.Since(lastStayOn) > time.Minute {
+			out, err := exec.Command("stay-on-for", "5").CombinedOutput()
+			if err != nil {
+				log.Errorf("error running stay-on-for: %s, error: %v", string(out), err)
+			} else {
+				lastStayOn = time.Now()
+			}
 		}
 	}()
 }

--- a/html/config.html
+++ b/html/config.html
@@ -35,14 +35,6 @@
                                 <td>stop recording</td>
                                 <td><input id=input-stop-recording></td>
                             </tr>
-                            <tr>
-                                <td>power on</td>
-                                <td><input id=input-power-on></td>
-                            </tr>
-                            <tr>
-                                <td>power off</td>
-                                <td><input id=input-power-off></td>
-                            </tr>
                         </tbody>
                     </table>
                 </div>

--- a/static/js/config.js
+++ b/static/js/config.js
@@ -22,13 +22,9 @@ async function loadConfig() {
     // Set placeholders and values for windows
     document.querySelector("#input-start-recording").placeholder = data.defaults.windows.StartRecording;
     document.querySelector("#input-stop-recording").placeholder = data.defaults.windows.StopRecording;
-    document.querySelector("#input-power-on").placeholder = data.defaults.windows.PowerOn;
-    document.querySelector("#input-power-off").placeholder = data.defaults.windows.PowerOff;
 
     document.querySelector("#input-start-recording").value = data.values.windows.StartRecording;
     document.querySelector("#input-stop-recording").value = data.values.windows.StopRecording;
-    document.querySelector("#input-power-on").value = data.values.windows.PowerOn;
-    document.querySelector("#input-power-off").value = data.values.windows.PowerOff;
 
     // Set placeholders and values for modem
     document.querySelector("#input-initial-on-duration").placeholder = formatDuration(data.defaults.modemd.InitialOnDuration);
@@ -83,8 +79,6 @@ async function saveWindowsConfig() {
   const data = {
     "start-recording": document.querySelector("#input-start-recording").value || undefined,
     "stop-recording": document.querySelector("#input-stop-recording").value || undefined,
-    "power-on": document.querySelector("#input-power-on").value || undefined,
-    "power-off": document.querySelector("#input-power-off").value || undefined,
   };
 
   await saveConfig("windows", data);


### PR DESCRIPTION
The request to tell the camera to stay on for 5 minutes would only run at most every 5 minutes, so it could be that a user was using the camera but it would still turn off.
This changes it so it will run the request to stay on for 5 minutes at most every 1 minute, not 5.
